### PR TITLE
Add more unit tests to improve code coverage

### DIFF
--- a/Devantler.AgeCLI.Tests/AgeKeygenTests/AddKeyAsyncTests.cs
+++ b/Devantler.AgeCLI.Tests/AgeKeygenTests/AddKeyAsyncTests.cs
@@ -1,20 +1,20 @@
-namespace Devantler.AgeCLI.Tests.AgeKeyTests;
+namespace Devantler.AgeCLI.Tests.AgeKeygenTests;
 
 /// <summary>
-/// Tests for the <see cref="AgeKeygenCLI.AddKeyAsync(bool, CancellationToken)"/> method and the <see cref="AgeKeygenCLI.AddKeyAsync(string, bool, bool, CancellationToken)"/> method.
+/// Tests for the <see cref="AgeKeygen.AddKeyAsync(bool, CancellationToken)"/> method and the <see cref="AgeKeygen.AddKeyAsync(string, bool, bool, CancellationToken)"/> method.
 /// </summary>
 public class GenerateKeyAsyncTests
 {
 
   /// <summary>
-  /// Tests that the <see cref="AgeKeygenCLI.AddKeyAsync(bool, CancellationToken)"/> method returns an age key.
+  /// Tests that the <see cref="AgeKeygen.AddKeyAsync(bool, CancellationToken)"/> method returns an age key.
   /// </summary>
   /// <returns></returns>
   [Fact]
   public async Task AddKeyAsync_ShouldReturnsAgeKey()
   {
     // Act
-    string key = await AgeKeygenCLI.AddKeyAsync();
+    string key = await AgeKeygen.AddKeyAsync();
 
     // Assert
     Assert.DoesNotContain("Public key:", key);
@@ -24,15 +24,15 @@ public class GenerateKeyAsyncTests
   }
 
   /// <summary>
-  /// Tests that the <see cref="AgeKeygenCLI.AddKeyAsync(bool, CancellationToken)"/> method returns an age key and adds the key to the sops age key file.
+  /// Tests that the <see cref="AgeKeygen.AddKeyAsync(bool, CancellationToken)"/> method returns an age key and adds the key to the sops age key file.
   /// </summary>
   /// <returns></returns>
   [Fact]
   public async Task AddKeyAsync_GivenBooleanToAddKeyToSopsAgeKeyFile_ShouldReturnAgeKeyAndAddsKeyToSopsAgeKeyFile()
   {
     // Act
-    string key = await AgeKeygenCLI.AddKeyAsync(addToSopsAgeKeyFile: true);
-    string sopsAgeKeyFileContents = await AgeKeygenCLI.ShowSopsAgeKeyFileAsync();
+    string key = await AgeKeygen.AddKeyAsync(addToSopsAgeKeyFile: true);
+    string sopsAgeKeyFileContents = await AgeKeygen.ShowSopsAgeKeyFileAsync();
 
     // Assert
     Assert.DoesNotContain("Public key:", key);
@@ -42,21 +42,21 @@ public class GenerateKeyAsyncTests
     Assert.Contains(key, sopsAgeKeyFileContents);
 
     // Cleanup
-    await AgeKeygenCLI.RemoveKeyFromSopsAgeKeyFileAsync(key);
-    sopsAgeKeyFileContents = await AgeKeygenCLI.ShowSopsAgeKeyFileAsync();
+    await AgeKeygen.RemoveKeyFromSopsAgeKeyFileAsync(key);
+    sopsAgeKeyFileContents = await AgeKeygen.ShowSopsAgeKeyFileAsync();
     Assert.DoesNotContain(key, sopsAgeKeyFileContents);
   }
 
   /// <summary>
-  /// Tests that the <see cref="AgeKeygenCLI.AddKeyAsync(string, bool, bool, CancellationToken)"/> method writes an age key to the specified file.
+  /// Tests that the <see cref="AgeKeygen.AddKeyAsync(string, bool, bool, CancellationToken)"/> method writes an age key to the specified file.
   /// </summary>
   /// <returns></returns>
   [Fact]
   public async Task AddKeyAsync_GivenValidPath_ShouldWriteKeyToFile()
   {
     // Act
-    await AgeKeygenCLI.AddKeyAsync("keys.txt", shouldOverwrite: true);
-    string keyContents = await AgeKeygenCLI.ShowKeyAsync("keys.txt");
+    await AgeKeygen.AddKeyAsync("keys.txt", shouldOverwrite: true);
+    string keyContents = await AgeKeygen.ShowKeyAsync("keys.txt");
 
     // Assert
     Assert.DoesNotContain("Public key:", keyContents);
@@ -65,21 +65,21 @@ public class GenerateKeyAsyncTests
     Assert.Contains("AGE-SECRET-KEY-", keyContents);
 
     // Cleanup
-    await AgeKeygenCLI.RemoveKeyAsync("keys.txt", removeFromSopsAgeKeyFile: false);
+    await AgeKeygen.RemoveKeyAsync("keys.txt", removeFromSopsAgeKeyFile: false);
     Assert.False(File.Exists("keys.txt"));
   }
 
   /// <summary>
-  /// Tests that the <see cref="AgeKeygenCLI.AddKeyAsync(string, bool, bool, CancellationToken)"/> method writes an age key to the specified file, and adds the key to the sops age key file.
+  /// Tests that the <see cref="AgeKeygen.AddKeyAsync(string, bool, bool, CancellationToken)"/> method writes an age key to the specified file, and adds the key to the sops age key file.
   /// </summary>
   /// <returns></returns>
   [Fact]
   public async Task AddKeyAsync_GivenValidPathAndBooleanToAddKeyToSopsAgeKeyFile_ShouldWriteKeyToFileAndAddKeyToSopsAgeKeyFile()
   {
     // Act
-    await AgeKeygenCLI.AddKeyAsync("keys.txt", shouldOverwrite: true, addToSopsAgeKeyFile: true);
-    string keyContents = await AgeKeygenCLI.ShowKeyAsync("keys.txt");
-    string sopsAgeKeyFileContents = await AgeKeygenCLI.ShowSopsAgeKeyFileAsync();
+    await AgeKeygen.AddKeyAsync("keys.txt", shouldOverwrite: true, addToSopsAgeKeyFile: true);
+    string keyContents = await AgeKeygen.ShowKeyAsync("keys.txt");
+    string sopsAgeKeyFileContents = await AgeKeygen.ShowSopsAgeKeyFileAsync();
 
     // Assert
     Assert.DoesNotContain("Public key:", keyContents);
@@ -89,9 +89,9 @@ public class GenerateKeyAsyncTests
     Assert.Contains(keyContents, sopsAgeKeyFileContents);
 
     // Cleanup
-    await AgeKeygenCLI.RemoveKeyAsync("keys.txt", removeFromSopsAgeKeyFile: true);
+    await AgeKeygen.RemoveKeyAsync("keys.txt", removeFromSopsAgeKeyFile: true);
     Assert.False(File.Exists("keys.txt"));
-    sopsAgeKeyFileContents = await AgeKeygenCLI.ShowSopsAgeKeyFileAsync();
+    sopsAgeKeyFileContents = await AgeKeygen.ShowSopsAgeKeyFileAsync();
     Assert.DoesNotContain(keyContents, sopsAgeKeyFileContents);
   }
 }

--- a/Devantler.AgeCLI.Tests/AgeKeygenTests/GetCommandTests.cs
+++ b/Devantler.AgeCLI.Tests/AgeKeygenTests/GetCommandTests.cs
@@ -1,0 +1,56 @@
+using System.Runtime.InteropServices;
+
+namespace Devantler.AgeCLI.Tests.AgeKeygenTests;
+
+public class GetCommandTests
+{
+  /// <summary>
+  /// Test to verify that the command returns the correct binary for MacOS on x64 architecture.
+  /// </summary>
+  [Fact]
+  public void Command_ShouldReturnDarwinAmd64Binary()
+  {
+    // Arrange
+    string expectedBinary = "age-keygen-darwin-amd64";
+
+    // Act
+    string actualBinary = Path.GetFileName(AgeKeygen.GetCommand(PlatformID.Unix, Architecture.X64, "osx-x64").TargetFilePath);
+
+    // Assert
+    Assert.Equal(expectedBinary, actualBinary);
+  }
+
+  /// <summary>
+  /// Test to verify that the command returns the correct binary for Linux on ARM64 architecture.
+  /// </summary>
+  [Fact]
+  public void Command_ShouldReturnLinuxArm64Binary()
+  {
+    // Arrange
+    string expectedBinary = "age-keygen-linux-arm64";
+
+    // Act
+    string actualBinary = Path.GetFileName(AgeKeygen.GetCommand(PlatformID.Unix, Architecture.Arm64, "linux-arm64").TargetFilePath);
+
+    // Assert
+    Assert.Equal(expectedBinary, actualBinary);
+  }
+
+  /// <summary>
+  /// Test to verify that the command returns a <see cref="PlatformNotSupportedException"/> when the platform is not supported.
+  /// </summary>
+  [Fact]
+  public void Command_GivenInvaldiPlatform_ShouldThrowPlatformNotSupportedException()
+  {
+    // Arrange
+    var platformID = PlatformID.Other;
+    var architecture = Architecture.Wasm;
+    string runtimeIdentifier = "wasm";
+
+    // Act
+    void Act() => AgeKeygen.GetCommand(platformID, architecture, runtimeIdentifier);
+
+    // Assert
+    Assert.Throws<PlatformNotSupportedException>(Act);
+  }
+}

--- a/Devantler.AgeCLI/Devantler.AgeCLI.csproj
+++ b/Devantler.AgeCLI/Devantler.AgeCLI.csproj
@@ -21,4 +21,8 @@
     <Content Include="assets/binaries/*linux-arm64" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="assets/binaries/*windows-amd64.exe" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Devantler.AgeCLI.Tests" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request adds additional unit tests to improve the code coverage of the project. The new tests cover scenarios related to the age-keygen CLI command, including verifying the correct binary for different platforms and architectures, and handling unsupported platforms. The tests ensure that the command behaves as expected and throws the appropriate exceptions when necessary.