### PR TITLE
Add unit test for ShowKeyAsync method

### DIFF
--- a/Devantler.AgeCLI.Tests/AgeKeygenTests/GetCommandTests.cs
+++ b/Devantler.AgeCLI.Tests/AgeKeygenTests/GetCommandTests.cs
@@ -2,6 +2,9 @@ using System.Runtime.InteropServices;
 
 namespace Devantler.AgeCLI.Tests.AgeKeygenTests;
 
+/// <summary>
+/// Tests for the <see cref="AgeKeygen.GetCommand(PlatformID?, Architecture?, string?)"/> method.
+/// </summary>
 public class GetCommandTests
 {
   /// <summary>

--- a/Devantler.AgeCLI.Tests/AgeKeygenTests/ShowKeyAsyncTests.cs
+++ b/Devantler.AgeCLI.Tests/AgeKeygenTests/ShowKeyAsyncTests.cs
@@ -1,0 +1,24 @@
+namespace Devantler.AgeCLI.Tests.AgeKeygenTests;
+
+/// <summary>
+/// Tests for the <see cref="AgeKeygen.ShowKeyAsync(string, CancellationToken)"/> method.
+/// </summary>
+public class ShowKeyAsyncTests
+{
+
+  /// <summary>
+  /// Tests that a <see cref="FileNotFoundException"/> is thrown when the key file does not exist.
+  /// </summary>
+  [Fact]
+  public async Task ShowKeyAsync_GivenNonExistentKeyFile_ShouldThrowFileNotFoundException()
+  {
+    // Arrange
+    string keyPath = "non-existent-key.txt";
+
+    // Act
+    async Task Act() => await AgeKeygen.ShowKeyAsync(keyPath);
+
+    // Assert
+    await Assert.ThrowsAsync<FileNotFoundException>(Act);
+  }
+}


### PR DESCRIPTION
This pull request adds a unit test for the ShowKeyAsync method in the AgeKeygenTests class. The test verifies that a FileNotFoundException is thrown when the key file does not exist.