### PR TITLE
Update Devantler.Keys.Age package version and enable self-contained and compressed build

### DIFF
--- a/Devantler.AgeCLI.Tests/AgeKeygenTests/InMemoryTests.cs
+++ b/Devantler.AgeCLI.Tests/AgeKeygenTests/InMemoryTests.cs
@@ -1,5 +1,5 @@
-using System.Globalization;
 using System.Text.RegularExpressions;
+using Devantler.AgeCLI.Tests.Utils;
 
 namespace Devantler.AgeCLI.Tests.AgeKeygenTests;
 
@@ -28,7 +28,7 @@ public partial class InMemoryTests
     Assert.NotEmpty(key.PrivateKey);
     Assert.Contains(
       NewlineRegex().Replace($"""
-        # created: {key.CreatedAt.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture)}
+        # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(key.CreatedAt)}
         # public key: {key.PublicKey}
         {key.PrivateKey}
         """, "\n" // The age-keygen CLI command always uses Unix-style line endings.

--- a/Devantler.AgeCLI/Devantler.AgeCLI.csproj
+++ b/Devantler.AgeCLI/Devantler.AgeCLI.csproj
@@ -8,11 +8,15 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+
+    <SelfContained>true</SelfContained>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Devantler.CLIRunner" Version="1.0.9" />
-    <PackageReference Include="Devantler.Keys.Age" Version="0.0.3" />
+    <PackageReference Include="Devantler.Keys.Age" Version="0.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the `Devantler.Keys.Age` package version to `0.0.4` and enables the self-contained and compressed build. The `SelfContained` property is set to `true`, `EnableCompressionInSingleFile` property is set to `true`, and `IncludeAllContentForSelfExtract` property is set to `true` in the project file. This ensures that the build is self-contained and compressed, making it easier to distribute and deploy the application.