### PR TITLE
Adjust createdAt data to UTC in Fix InMemory method

### DIFF
--- a/Devantler.AgeCLI/AgeKeygen.cs
+++ b/Devantler.AgeCLI/AgeKeygen.cs
@@ -50,7 +50,7 @@ public static class AgeKeygen
     string[] lines = message.Split(Environment.NewLine);
     string publicKey = lines[1].Split(" ")[3];
     string privateKey = lines[2];
-    var createdAt = DateTime.Parse(lines[0].Split(" ")[2], CultureInfo.InvariantCulture);
+    var createdAt = DateTime.Parse(lines[0].Split(" ")[2], CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
     var key = new AgeKey(
       publicKey,
       privateKey,

--- a/Devantler.AgeCLI/Devantler.AgeCLI.csproj
+++ b/Devantler.AgeCLI/Devantler.AgeCLI.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Devantler.CLIRunner" Version="1.0.9" />
-    <PackageReference Include="Devantler.Keys.Age" Version="0.0.4" />
+    <PackageReference Include="Devantler.Keys.Age" Version="0.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Fix InMemory method has been updated to adjust the createdAt data to UTC. This ensures that the createdAt timestamp is accurate and consistent across different time zones.