### PR TITLE
Update Devantler.Keys.Age package version to 0.0.8

### DIFF
--- a/Devantler.AgeCLI/Devantler.AgeCLI.csproj
+++ b/Devantler.AgeCLI/Devantler.AgeCLI.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Devantler.CLIRunner" Version="1.0.9" />
-    <PackageReference Include="Devantler.Keys.Age" Version="0.0.7" />
+    <PackageReference Include="Devantler.Keys.Age" Version="0.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the version of the Devantler.Keys.Age package to 0.0.8.