### PR TITLE
Update binary path handling

### DIFF
--- a/Devantler.AgeCLI/AgeKeygen.cs
+++ b/Devantler.AgeCLI/AgeKeygen.cs
@@ -31,7 +31,7 @@ public static class AgeKeygen
       (PlatformID.Win32NT, Architecture.X64, "win-x64") => "age-keygen-win-x64.exe",
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
-    string binaryPath = $"{AppContext.BaseDirectory}/runtimes/{runtimeIdentifier}/native/{binary}";
+    string binaryPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "runtimes", runtimeIdentifier, "native", binary);
     return !File.Exists(binaryPath) ?
       throw new FileNotFoundException($"{binaryPath} not found.") :
       Cli.Wrap(binaryPath);


### PR DESCRIPTION
This pull request updates the handling of the binary path in the code. Previously, the binary path was constructed using string concatenation, but now it is constructed using the `Path.Combine` method. This change ensures that the binary path is correctly formed and avoids any potential issues with path separators.