### PR TITLE
Refactor variable name from message to output in RunAsync method

### DIFF
--- a/Devantler.AgeCLI.Tests/AgeKeygenTests/RunAsyncTests.cs
+++ b/Devantler.AgeCLI.Tests/AgeKeygenTests/RunAsyncTests.cs
@@ -15,10 +15,10 @@ public class RunAsyncTests
   public async Task RunAsync_Version_ReturnsVersion()
   {
     // Act
-    var (exitCode, message) = await AgeKeygen.RunAsync(["--version"]);
+    var (exitCode, output) = await AgeKeygen.RunAsync(["--version"]);
 
     // Assert
     Assert.Equal(0, exitCode);
-    Assert.Matches(@"^v\d+\.\d+\.\d+$", message.Trim());
+    Assert.Matches(@"^v\d+\.\d+\.\d+$", output.Trim());
   }
 }

--- a/Devantler.AgeCLI/AgeKeygen.cs
+++ b/Devantler.AgeCLI/AgeKeygen.cs
@@ -70,16 +70,16 @@ public static class AgeKeygen
   [Obsolete("This method is deprecated. Use RunAsync instead.")]
   public static async Task<AgeKey> InMemory(CancellationToken cancellationToken = default)
   {
-    var (exitCode, message) = await RunAsync(
+    var (exitCode, output) = await RunAsync(
       [],
       silent: true,
       includeStdErr: false,
       cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to generate key: {message}");
+      throw new InvalidOperationException($"Failed to generate key: {output}");
     }
-    string[] lines = message.Split(Environment.NewLine);
+    string[] lines = output.Split(Environment.NewLine);
     var createdAt = DateTime.Parse(lines[0].Split(" ")[2], CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
     string publicKey = lines[1].Split(" ")[3];
     string privateKey = lines[2];
@@ -101,10 +101,10 @@ public static class AgeKeygen
   [Obsolete("This method is deprecated. Use RunAsync instead.")]
   public static async Task<AgeKey> ToFile(string path, CancellationToken cancellationToken = default)
   {
-    var (exitCode, message) = await RunAsync(["-o", path], silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, output) = await RunAsync(["-o", path], silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to generate key: {message}");
+      throw new InvalidOperationException($"Failed to generate key: {output}");
     }
     string key = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
     string[] lines = key.Split("\n");

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ dotnet add package Devantler.AgeCLI
 ```csharp
 using Devantler.AgeCLI;
 
-var (exitCode, message) = await AgeKeygen.RunAsync(["arg1", "arg2"]);
+var (exitCode, output) = await AgeKeygen.RunAsync(["arg1", "arg2"]);
 ```


### PR DESCRIPTION
Rename the variable used to capture output in the RunAsync method and related tests for clarity and consistency.